### PR TITLE
Add default order

### DIFF
--- a/src/basic/points.js
+++ b/src/basic/points.js
@@ -138,7 +138,7 @@ Point.getDraw = function(c3ss, id) {
 
     point.collide = !getCollide(c3ss);
 	}
-
+  point.order = 0;
   draw['points_' + id] = point;
 
   return draw;

--- a/test/basic/points.js
+++ b/test/basic/points.js
@@ -116,6 +116,9 @@ describe( 'Point', () => {
       assert.equal(point.collide, false);
     });
 
+    it('should have order 0 by default', () => {
+      assert.equal(point.order, 0);
+    });
 
   });
 


### PR DESCRIPTION
From #48:

> According to the Tangram doc the order field is required in the "draw" field unless the blend_mode equals to overlay causing the markers to be invisible.

This PR adds a default order for the markers making them visible when the blend mode is different from overlay and is supported according to the tangram-reference.